### PR TITLE
remove TD from scene if undefined

### DIFF
--- a/app/assets/javascripts/components/_limbforgeForm.js.jsx
+++ b/app/assets/javascripts/components/_limbforgeForm.js.jsx
@@ -155,6 +155,7 @@ var LimbforgeForm = React.createClass({
     var newSpecs = self.state.specs;
     if (event.target.value == ""){
       newSpecs.TD = undefined;
+      scene.remove(scene.children[4]);
     }
     else{
       newSpecs.TD = event.target.value;


### PR DESCRIPTION
Includes fix for removing a TD on the .stl display if it is undefined in the sidebar

Check it out on [staging1](https://limbforge-staging1.herokuapp.com/limbforge)
